### PR TITLE
Load features config inside `FeatureFlagsPlugin::bootstrap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 #######################
 # PHPUnit
 .phpunit.cache
+.phpunit.result.cache
 tests.sqlite
 # vim
 *~

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The recommended way to install composer packages is:
 composer require markstory/cakephp-feature-flags
 ```
 
+Next, load the plugin by running the following command:
+
+```
+bin/cake plugin load FeatureFlags
+```
+
 ## Usage
 
 First you need to decide if you want simple boolean feature flags, or more complex
@@ -37,13 +43,6 @@ return [
         'checkout-v2' => false,
     ],
 ];
-```
-
-Next, in `config/bootstrap.php` add the following:
-
-```php
-// Load the feature configuration during application startup.
-Configure::load('features');
 ```
 
 In your `Application::services()` method add the following:
@@ -102,13 +101,6 @@ return [
         ],
     ],
 ];
-```
-
-Next, in `config/bootstrap.php` add the following:
-
-```php
-// Load the feature configuration during application startup.
-Configure::load('features');
 ```
 
 In your `Application::services()` method add the following:

--- a/src/FeatureFlagsPlugin.php
+++ b/src/FeatureFlagsPlugin.php
@@ -5,6 +5,8 @@ namespace FeatureFlags;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Core\PluginApplicationInterface;
 
 /**
  * Plugin for FeatureFlags
@@ -12,10 +14,7 @@ use Cake\Core\BasePlugin;
 class FeatureFlagsPlugin extends BasePlugin
 {
     /**
-     * Add commands for the plugin.
-     *
-     * @param \Cake\Console\CommandCollection $commands The command collection to update.
-     * @return \Cake\Console\CommandCollection
+     * @inheritDoc
      */
     public function console(CommandCollection $commands): CommandCollection
     {
@@ -25,5 +24,12 @@ class FeatureFlagsPlugin extends BasePlugin
         // TODO add feature flag validation tool?
 
         return $commands;
+    }
+
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        parent::bootstrap($app);
+
+        Configure::load('features');
     }
 }

--- a/src/FeatureFlagsPlugin.php
+++ b/src/FeatureFlagsPlugin.php
@@ -26,6 +26,9 @@ class FeatureFlagsPlugin extends BasePlugin
         return $commands;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function bootstrap(PluginApplicationInterface $app): void
     {
         parent::bootstrap($app);


### PR DESCRIPTION
I didn't see any good reason not do this, as it saves us one step during setup.